### PR TITLE
Refactor: Ajusta a intenção de compartilhamento de relatório

### DIFF
--- a/app/src/main/java/br/com/app/src/main/kotlin/com/habitus/presentation/screens/SettingsScreen.kt
+++ b/app/src/main/java/br/com/app/src/main/kotlin/com/habitus/presentation/screens/SettingsScreen.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -18,8 +17,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import android.widget.Toast
-import android.util.Log
 import androidx.navigation.NavController
 import br.com.app.src.main.kotlin.com.habitus.presentation.navigation.destinations.navigateToInitialForm
 import br.com.app.src.main.kotlin.com.habitus.presentation.viewmodels.SettingsViewModel
@@ -27,7 +24,6 @@ import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.userProfileChangeRequest
 import androidx.core.content.edit
-import br.com.app.src.main.kotlin.com.habitus.presentation.viewmodels.SettingsViewModel
 
 @Composable
 fun SettingsScreen(navController: NavController, viewModel: SettingsViewModel) {

--- a/app/src/main/java/br/com/app/src/main/kotlin/com/habitus/presentation/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/br/com/app/src/main/kotlin/com/habitus/presentation/viewmodels/SettingsViewModel.kt
@@ -6,19 +6,13 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.io.File
-import javax.inject.Inject
 import br.com.app.src.main.kotlin.com.habitus.data.repository.HabitRepository
 import android.content.Intent
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import android.content.Context
 import androidx.core.content.edit
-import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import jakarta.inject.Inject
 
@@ -47,12 +41,13 @@ class SettingsViewModel @Inject constructor(
                     file
                 )
 
-                val intent = Intent(Intent.ACTION_VIEW).apply {
-                    setDataAndType(uri, "text/plain")
-                    flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK
+                val intent = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
 
-                context.startActivity(intent)
+                context.startActivity(Intent.createChooser(intent, "Compartilhar relatório"))
 
                 onSuccess()
             } catch (e: Exception) {


### PR DESCRIPTION
- Modifica a ação da intenção de `ACTION_VIEW` para `ACTION_SEND` para permitir o compartilhamento do arquivo de relatório.
- Adiciona `Intent.EXTRA_STREAM` para anexar o arquivo à intenção.
- Utiliza `Intent.createChooser` para apresentar ao usuário uma lista de aplicativos para compartilhamento.
- Remove importações não utilizadas em `SettingsViewModel` e `SettingsScreen`.